### PR TITLE
Fixed issues related with new Polls first generated Instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Version Changelog
 
+## 0.3.1
+
+### Fixes
+
+- Fixed issues where you could not generate new instances of recently created Polls.
+- Fixed issues where if a Poll was not iterated, instances endpoint would not iterate and generated previous instances when being called for the first time.
+
 ## 0.3.0
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "programmed-polls-backend-rest-api",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "firebase-admin": "^12.1.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "devDependencies": {
     "@types/node": "^20.14.2",


### PR DESCRIPTION
# Version Changelog

## 0.3.1

### Fixes

- Fixed issues where you could not generate new instances of recently created Polls.
- Fixed issues where if a Poll was not iterated, instances endpoint would not iterate and generated previous instances when being called for the first time.
