### PR TITLE
Automatically create instance if a poll is created in current time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Version Changelog
 
+## 1.0.2
+
+### Improvements
+
+- Refactored instances creation as an util function
+- If an user creates a poll with no startTime or with the same startTime as current time, poll's instances will be created automatically as soon as the poll is created
+
 ## 1.0.1
 
 ### Improvements

--- a/api/core/instances.ts
+++ b/api/core/instances.ts
@@ -1,7 +1,7 @@
 import { db } from '../../config/firebaseConfig'
 import { Timestamp } from 'firebase-admin/firestore'
-import { Instance } from '../../models/dataInterfaces'
 import { VercelRequest, VercelResponse } from '@vercel/node'
+import { createInstance } from '../../utils/createInstance'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   const { method } = req
@@ -108,23 +108,4 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       res.setHeader('Allow', ['POST'])
       return res.status(405).end(`Method ${method} Not Allowed`)
   }
-}
-
-async function createInstance(
-  pollId: string,
-  duration: number,
-  startTime: Timestamp,
-) {
-  const endTime = Timestamp.fromDate(
-    new Date(startTime.toDate().getTime() + duration * 24 * 60 * 60 * 1000),
-  )
-
-  const newInstance: Instance = {
-    pollId,
-    startTime,
-    endTime,
-  }
-
-  const instanceRef = await db.collection('instances').add(newInstance)
-  return instanceRef.id
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "programmed-polls-backend-rest-api",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dependencies": {
         "firebase-admin": "^12.2.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "devDependencies": {
     "@types/node": "^20.14.9",

--- a/utils/createInstance.ts
+++ b/utils/createInstance.ts
@@ -1,0 +1,22 @@
+import { Timestamp } from 'firebase-admin/firestore'
+import { Instance } from '../models/dataInterfaces'
+import { db } from '../config/firebaseConfig'
+
+export async function createInstance(
+  pollId: string,
+  duration: number,
+  startTime: Timestamp,
+) {
+  const endTime = Timestamp.fromDate(
+    new Date(startTime.toDate().getTime() + duration * 24 * 60 * 60 * 1000),
+  )
+
+  const newInstance: Instance = {
+    pollId,
+    startTime,
+    endTime,
+  }
+
+  const instanceRef = await db.collection('instances').add(newInstance)
+  return instanceRef.id
+}


### PR DESCRIPTION
# Version Changelog

## 1.0.2

### Improvements

- Refactored instances creation as an util function
- If an user creates a poll with no startTime or with the same startTime as current time, poll's instances will be created automatically as soon as the poll is created