### PR TITLE
Any logged user is now allowed to get a poll by ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Version Changelog
 
+## 1.0.4
+
+### Fixes
+
+- Any user will be able to get a single Poll by ID. This will not provide any sensitive information and will only be possible if Poll owner shared their Poll ID with them.
+
 ## 1.0.3
 
 ### Fixes

--- a/api/core/polls/[id].ts
+++ b/api/core/polls/[id].ts
@@ -31,12 +31,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
         const pollData = pollDoc.data() as Poll
 
-        // Ensure that the poll belongs to the authenticated user
-        if (pollData.userId !== userId) {
-          return res.status(403).json({
-            message: 'Forbidden, you do not have access to this poll',
-          })
-        }
+        // (Not necessary for GetByID) Ensure that the poll belongs to the authenticated user
+        // if (pollData.userId !== userId) {
+        //   return res.status(403).json({
+        //     message: 'Forbidden, you do not have access to this poll',
+        //   })
+        // }
 
         const response = {
           pollId: id,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "programmed-polls-backend-rest-api",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dependencies": {
         "cors": "^2.8.5",
         "firebase-admin": "^12.2.0"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "devDependencies": {
     "@types/node": "^20.14.9",


### PR DESCRIPTION
# Version Changelog

## 1.0.4

### Fixes

- Any user will be able to get a single Poll by ID. This will not provide any sensitive information and will only be possible if Poll owner shared their Poll ID with them.